### PR TITLE
Refactor Result interface to sealed class

### DIFF
--- a/src/applicative/ApplicativeResult.kt
+++ b/src/applicative/ApplicativeResult.kt
@@ -1,8 +1,8 @@
 package applicative
 
-interface Result<T>
-class Ok<T>(val value: T) : Result<T>
-class Error<T>(val error: String) : Result<T>
+sealed class Result<T>
+class Ok<T>(val value: T) : Result<T>()
+class Error<T>(val error: String) : Result<T>()
 
 fun <a> id(x: a): a = x
 
@@ -11,7 +11,6 @@ fun <a> rtrn(x: a): Result<a> = Ok(x)
 fun <a, b> map(f: ((a) -> b), rx: Result<a>): Result<b> = when (rx) {
     is Ok -> Ok(f(rx.value))
     is Error -> Error(rx.error)
-    else -> Error("") // Not reachable
 }
 
 fun <a, b, c> map2(f: ((a) -> (b) -> c), ra: Result<a>, rb: Result<b>): Result<c> =

--- a/src/functor/FunctorResult.kt
+++ b/src/functor/FunctorResult.kt
@@ -1,8 +1,8 @@
 package functor
 
-interface Result<T>
-class Ok<T>(val value: T) : Result<T>
-class Error<T>(val error: String) : Result<T>
+sealed class Result<T>
+class Ok<T>(val value: T) : Result<T>()
+class Error<T>(val error: String) : Result<T>()
 
 fun <T> id(x: T): T = throw NotImplementedError()
 

--- a/src/functor/løsninger/løsning-1.md
+++ b/src/functor/løsninger/løsning-1.md
@@ -6,6 +6,5 @@ fun <a> rtrn(x: a): Result<a> = Ok(x)
 fun <a, b> map(f: ((a) -> b), rx: Result<a>): Result<b> = when (rx) {
     is Ok -> Ok(f(rx.value))
     is Error -> Error(rx.error)
-    else -> Error("") // Not reachable
 }
 ```

--- a/src/monad/MonadResult.kt
+++ b/src/monad/MonadResult.kt
@@ -1,8 +1,8 @@
 package monad
 
-interface Result<T>
-class Ok<T>(val value: T) : Result<T>
-class Error<T>(val error: String) : Result<T>
+sealed class Result<T>
+class Ok<T>(val value: T) : Result<T>()
+class Error<T>(val error: String) : Result<T>()
 
 fun <T> id(x: T): T = x
 
@@ -37,7 +37,6 @@ infix fun <a, b> Result<((a)->b)>.`‹*›`(rx: Result<a>) : Result<b> = apply(t
 fun <a, b> map(f: ((a) -> b), rx: Result<a>): Result<b> = when (rx) {
     is Ok -> Ok(f(rx.value))
     is Error -> Error(rx.error)
-    else -> Error("") // Not reachable
 }
 
 infix fun <a, b> ((a) -> b).`‹!›`(rx: Result<a>): Result<b> = map(this, rx)

--- a/src/monad/løsninger/løsning-1.md
+++ b/src/monad/løsninger/løsning-1.md
@@ -2,7 +2,6 @@
 fun <a> flatten(rrx: Result<Result<a>>): Result<a> = when (rrx) {
     is Ok -> rrx.value
     is Error -> Error(rrx.error)
-    else -> Error("")
 }
 
 fun <a, b> bind(rx: Result<a>, f: (a) -> Result<b>) : Result<b> = flatten(map(rx, f))

--- a/src/monad/løsninger/løsning-2.md
+++ b/src/monad/løsninger/løsning-2.md
@@ -2,7 +2,6 @@
 fun <a, b> bind(rx: Result<a>, f: (a) -> Result<b>) : Result<b> = when (rx) {
     is Ok -> f(rx.value)
     is Error -> Error(rx.error)
-    else -> Error("")
 }
 
 fun <a, b, c> kleisliCompose(f: (b) -> Result<c>, g: (a) -> Result<b>): (a) -> Result<c> = { x: a -> bind(g(x), f) }


### PR DESCRIPTION
Sealed classes in Kotlin can be exhaustively matched in `when` clauses, so by
using a sealed class we can skip a branch here and there.